### PR TITLE
Fix incorrect reference pointing to id instead of query_id

### DIFF
--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
@@ -25,7 +25,7 @@ class ScheduledQueriesSection extends Component {
             return (
               <li key={`scheduled-query-${scheduledQuery.id}`}>
                 <Link
-                  to={PATHS.EDIT_QUERY(scheduledQuery)}
+                  to={PATHS.EDIT_QUERY({ id: scheduledQuery.query_id })}
                   className={`${baseClass}__query-name`}
                 >
                   {scheduledQuery.name}

--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
@@ -12,7 +12,7 @@ describe("ScheduledQueriesSection - component", () => {
       <ScheduledQueriesSection scheduledQueries={[scheduledQuery]} />
     );
     const Link = Component.find("Link");
-    const path = `${PATHS.EDIT_QUERY(scheduledQuery)}`;
+    const path = `${PATHS.EDIT_QUERY({ id: scheduledQuery.query_id })}`;
 
     expect(Link.prop("to")).toEqual(path);
   });


### PR DESCRIPTION
Resolves bug raised by @noahtalerman in https://github.com/fleetdm/fleet/pull/769 